### PR TITLE
fix: Use relative path for script in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Changes the script path in `index.html` from absolute to relative. This ensures that the browser correctly locates the main script file on GitHub Pages deployments, where the site is served from a subdirectory.

This fixes the 404 error that was causing a blank page on the deployed site.