### PR TITLE
fix: Revert to absolute path for script in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Reverts the script path in `index.html` back to an absolute path (`/src/main.tsx`). This is the standard configuration for Vite, which processes this path during the build and replaces it with the correct path to the bundled assets.

This change is intended to fix the MIME type error on the deployed site, which was caused by the browser attempting to load a raw TypeScript file instead of the built JavaScript file.