### PR TITLE
chore: Trigger new deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+
 // https://vitejs.dev/config/
+// Triggering a new deployment after changing GitHub Pages source.
 export default defineConfig(({ mode }) => ({
   base: mode === 'production' ? '/supplymarinegeral/' : '/',
   server: {


### PR DESCRIPTION
Adds a comment to `vite.config.ts` to trigger a new deployment workflow. This is done after changing the GitHub Pages source setting to 'GitHub Actions'.