### PR TITLE
feat: Adiciona cards de unidades vazias para o cliente Modec

### DIFF
--- a/src/components/dashboard/MaritimeDashboard.tsx
+++ b/src/components/dashboard/MaritimeDashboard.tsx
@@ -196,9 +196,13 @@ export const MaritimeDashboard = () => {
   const renderUnidades = () => {
     if (!navigation.selectedCliente) return null;
 
+    const novasUnidadesNomes = ['MV15', 'MV18', 'MV20', 'MV22', 'MV23', 'MV24', 'MV26', 'MV27', 'MV29', 'MV30', 'MV31'];
+    const novasUnidades = novasUnidadesNomes.map(name => ({ name, sistemas: 0, equipamentos: 0 }));
+
     const unidades = [
       { name: 'FPSO Bacalhau', sistemas: totalSistemasBacalhau, equipamentos: totalEquipamentosBacalhau },
       { name: 'FPSO Fluminense', sistemas: totalSistemasFluminense, equipamentos: totalEquipamentosFluminense },
+      ...novasUnidades,
     ];
 
     return (
@@ -252,7 +256,13 @@ export const MaritimeDashboard = () => {
       totalSistemasCliente = siemensSystemsData.length;
       clienteTitle = "Sistemas - Siemens";
     } else if (navigation.selectedCliente === 'Modec') {
-      const systemData = navigation.selectedUnidade === 'FPSO Fluminense' ? fluminenseSystemsData : modecSystemsData;
+      let systemData: SystemData[] = [];
+      if (navigation.selectedUnidade === 'FPSO Bacalhau') {
+        systemData = modecSystemsData;
+      } else if (navigation.selectedUnidade === 'FPSO Fluminense') {
+        systemData = fluminenseSystemsData;
+      }
+
       filteredSistemas = systemData.filter((sistema) =>
         sistema.nome.toLowerCase().includes(searchTerms.sistemas.toLowerCase()) ||
         sistema.tipo.toLowerCase().includes(searchTerms.sistemas.toLowerCase())


### PR DESCRIPTION
- Adiciona 11 novos cards de unidades (MV15, MV18, etc.) na tela de seleção de unidades da Modec.
- Configura os novos cards para exibir '0 sistemas' e '0 equipamentos'.
- Garante que, ao clicar em um novo card, uma lista de sistemas vazia seja exibida.