### PR TITLE
chore: Remove unidades não utilizadas da Modec

### DIFF
--- a/src/components/dashboard/MaritimeDashboard.tsx
+++ b/src/components/dashboard/MaritimeDashboard.tsx
@@ -196,7 +196,7 @@ export const MaritimeDashboard = () => {
   const renderUnidades = () => {
     if (!navigation.selectedCliente) return null;
 
-    const novasUnidadesNomes = ['MV20', 'MV22', 'MV23', 'MV26', 'MV27', 'MV29', 'MV30', 'MV31'];
+    const novasUnidadesNomes = ['MV20', 'MV22', 'MV23', 'MV26', 'MV29', 'MV30', 'MV31'];
     const novasUnidades = novasUnidadesNomes.map(name => ({ name, sistemas: 0, equipamentos: 0 }));
 
     const unidades = [


### PR DESCRIPTION
- Remove os cards das unidades MV15, MV24 e MV27 da interface do cliente Modec.
- Remove a unidade FPSO Fluminense, incluindo a exclusão do seu arquivo de dados e a limpeza de todas as referências de código relacionadas.