### PR TITLE
feat: Adiciona dados e sistemas para a unidade MV23

### DIFF
--- a/src/components/dashboard/MaritimeDashboard.tsx
+++ b/src/components/dashboard/MaritimeDashboard.tsx
@@ -16,6 +16,7 @@ import { modecEquipmentData, modecSystemsData, getTiposSistemaModec, getTotalEqu
 import { mv18SystemsData, getTotalEquipamentosMv18 } from '@/data/mv18Equipment';
 import { mv20SystemsData, getTotalEquipamentosMv20 } from '@/data/mv20Equipment';
 import { mv22SystemsData, getTotalEquipamentosMv22 } from '@/data/mv22Equipment';
+import { mv23SystemsData, getTotalEquipamentosMv23 } from '@/data/mv23Equipment';
 type ViewLevel = 'overview' | 'cliente' | 'unidade' | 'sistema' | 'sistemaDetail';
 
 interface NavigationState {
@@ -108,9 +109,11 @@ export const MaritimeDashboard = () => {
   const totalEquipamentosMv20 = getTotalEquipamentosMv20();
   const totalSistemasMv22 = mv22SystemsData.length;
   const totalEquipamentosMv22 = getTotalEquipamentosMv22();
+  const totalSistemasMv23 = mv23SystemsData.length;
+  const totalEquipamentosMv23 = getTotalEquipamentosMv23();
   
-  const totalSistemasModec = totalSistemasBacalhau + totalSistemasMv18 + totalSistemasMv20 + totalSistemasMv22;
-  const totalEquipamentosModec = totalEquipamentosBacalhau + totalEquipamentosMv18 + totalEquipamentosMv20 + totalEquipamentosMv22;
+  const totalSistemasModec = totalSistemasBacalhau + totalSistemasMv18 + totalSistemasMv20 + totalSistemasMv22 + totalSistemasMv23;
+  const totalEquipamentosModec = totalEquipamentosBacalhau + totalEquipamentosMv18 + totalEquipamentosMv20 + totalEquipamentosMv22 + totalEquipamentosMv23;
 
   const totalSistemas = totalSistemasSiemens + totalSistemasModec;
   const totalEquipamentos = totalEquipamentosSiemens + totalEquipamentosModec;
@@ -202,7 +205,7 @@ export const MaritimeDashboard = () => {
   const renderUnidades = () => {
     if (!navigation.selectedCliente) return null;
 
-    const novasUnidadesNomes = ['MV23', 'MV26', 'MV29', 'MV30', 'MV31'];
+    const novasUnidadesNomes = ['MV26', 'MV29', 'MV30', 'MV31'];
     const novasUnidades = novasUnidadesNomes.map(name => ({ name, sistemas: 0, equipamentos: 0 }));
 
     const unidades = [
@@ -210,6 +213,7 @@ export const MaritimeDashboard = () => {
       { name: 'MV18', sistemas: totalSistemasMv18, equipamentos: totalEquipamentosMv18 },
       { name: 'MV20', sistemas: totalSistemasMv20, equipamentos: totalEquipamentosMv20 },
       { name: 'MV22', sistemas: totalSistemasMv22, equipamentos: totalEquipamentosMv22 },
+      { name: 'MV23', sistemas: totalSistemasMv23, equipamentos: totalEquipamentosMv23 },
       ...novasUnidades,
     ];
 
@@ -273,6 +277,8 @@ export const MaritimeDashboard = () => {
         systemData = mv20SystemsData;
       } else if (navigation.selectedUnidade === 'MV22') {
         systemData = mv22SystemsData;
+      } else if (navigation.selectedUnidade === 'MV23') {
+        systemData = mv23SystemsData;
       }
 
       filteredSistemas = systemData.filter((sistema) =>

--- a/src/data/mv23Equipment.ts
+++ b/src/data/mv23Equipment.ts
@@ -1,0 +1,140 @@
+import { SystemData } from './modecEquipment';
+
+export const mv23SystemsData: SystemData[] = [
+  {
+    numero: 1,
+    nome: "Sistema de Climatização: Acomodações (Principal)",
+    tipo: "Split System de Alta Capacidade",
+    local: "Casario",
+    equipamentos: [
+      { code: "ZZZ-8245-04-A1", description: "Unidade de Tratamento de Ar (AHU) A1", fabricante: "Ushio Reinetsu", modelo: "UAH-155", capacidade: "320,0 kW" },
+      { code: "ZZZ-8245-04-A2", description: "Unidade de Tratamento de Ar (AHU) A2", fabricante: "Ushio Reinetsu", modelo: "UAH-155", capacidade: "320,0 kW" },
+      { code: "ZZZ-8245-04-B1", description: "Unidade de Tratamento de Ar (AHU) B1", fabricante: "Ushio Reinetsu", modelo: "UAH-155", capacidade: "320,0 kW" },
+      { code: "ZZZ-8245-04-B2", description: "Unidade de Tratamento de Ar (AHU) B2", fabricante: "Ushio Reinetsu", modelo: "UAH-155", capacidade: "320,0 kW" },
+      { code: "ER-ZZZ-8245-01A", description: "Unidade Condensadora A", fabricante: "Ushio Reinetsu", modelo: "UAC-750SFS4", capacidade: "105,5 kW" },
+      { code: "ER-ZZZ-8245-01B", description: "Unidade Condensadora B", fabricante: "Ushio Reinetsu", modelo: "UAC-750SFS4", capacidade: "105,5 kW" },
+      { code: "ER-ZZZ-8245-01C", description: "Unidade Condensadora C", fabricante: "Ushio Reinetsu", modelo: "UAC-750SFS4", capacidade: "105,5 kW" },
+    ],
+  },
+  {
+    numero: 2,
+    nome: "Sistema de Climatização: E-House",
+    tipo: "Rooftop",
+    local: "E-House",
+    equipamentos: [
+      { code: "7S-ZZZ-8280A", description: "Rooftop Alpha", fabricante: "Jiangsu Yongsheng", modelo: "MPC(F)-25", capacidade: "281,0 kW" },
+      { code: "7S-ZZZ-8280B", description: "Rooftop Bravo", fabricante: "Jiangsu Yongsheng", modelo: "MPC(F)-25", capacidade: "281,0 kW" },
+    ],
+  },
+  {
+    numero: 3,
+    nome: "Sistema de Climatização: EER",
+    tipo: "Self Contained",
+    local: "EER",
+    equipamentos: [
+      { code: "SD-ZZZ-8250-02A", description: "Self Contained Alpha", fabricante: "Ushio Reinetsu", modelo: "UAP-7HF4DL4", capacidade: "32,4 kW" },
+      { code: "SD-ZZZ-8250-02B", description: "Self Contained Bravo", fabricante: "Ushio Reinetsu", modelo: "UAP-7HF4DL4", capacidade: "32,4 kW" },
+    ],
+  },
+  {
+    numero: 4,
+    nome: "Sistema de Climatização: Sala de Controle de Motores (ECR)",
+    tipo: "Self Contained",
+    local: "ECR",
+    equipamentos: [
+      { code: "ER-ZZZ-8255-01", description: "Self Contained", fabricante: "Ushio Reinetsu", modelo: "UAP-7HF4DL4", capacidade: "32,4 kW" },
+    ],
+  },
+  {
+    numero: 5,
+    nome: "Sistema de Climatização: Sala de Controle Central (CCR)",
+    tipo: "Self Contained",
+    local: "CCR",
+    equipamentos: [
+      { code: "UD-ZZZ-8250-01A", description: "Self Contained Alpha", fabricante: "Ushio Reinetsu", modelo: "UAP-5HF4DL4", capacidade: "24,6 kW" },
+      { code: "UD-ZZZ-8250-01B", description: "Self Contained Bravo", fabricante: "Ushio Reinetsu", modelo: "UAP-5HF4DL4", capacidade: "24,6 kW" },
+    ],
+  },
+  {
+    numero: 6,
+    nome: "Sistemas de Climatização: Salas de Rádio e Telecomunicações",
+    tipo: "Split System",
+    local: "Sala de Rádio e Telecom",
+    equipamentos: [
+      { code: "ND-ZZZ-8250-06A", description: "AHU da Sala de Rádio", fabricante: "Mitsubishi", modelo: "PFAV-P140VCM-E", capacidade: "14,0 kW" },
+      { code: "ND-ZZZ-8250-06B", description: "ACCU da Sala de Rádio", fabricante: "Mitsubishi", modelo: "PUHV-P140VCM-E-BSG", capacidade: "14,0 kW" },
+      { code: "ND-ZZZ-8250-05A", description: "AHU de Telecom", fabricante: "Mitsubishi", modelo: "PFAV-P224VCM-E", capacidade: "22,4 kW" },
+      { code: "ND-ZZZ-8250-05B", description: "ACCU de Telecom", fabricante: "Mitsubishi", modelo: "PUHV-P224VCM-E-BSG", capacidade: "22,4 kW" },
+      { code: "", description: "Split de Apoio Alpha", tipo: "Split System Hi-Wall", fabricante: "Electrolux", modelo: "VE18F / VI18F", capacidade: "5,27 kW" },
+      { code: "", description: "Split de Apoio Bravo", tipo: "Split System Hi-Wall", fabricante: "Electrolux", modelo: "VE18F / VI18F", capacidade: "5,27 kW" },
+    ],
+  },
+  {
+    numero: 7,
+    nome: "Sistema de Refrigeração: Provisões",
+    tipo: "Unidade Condensadora",
+    local: "Área de Provisões",
+    equipamentos: [
+      { code: "ER-ZZZ-8265-01A", description: "Unidade Condensadora Alpha", fabricante: "Ushio Reinetsu", modelo: "URS-7.5SSFB4", capacidade: "7,14 kW" },
+      { code: "ER-ZZZ-8265-01B", description: "Unidade Condensadora Bravo", fabricante: "Ushio Reinetsu", modelo: "URS-7.5SSFB4", capacidade: "7,14 kW" },
+      { code: "UD-ZZZ-8265-02A", description: "Forçador de Ar | Câmara de Carnes", fabricante: "Ushio Reinetsu", modelo: "UTSA-37HT", capacidade: "3,83 kW" },
+      { code: "UD-ZZZ-8265-02B", description: "Forçador de Ar | Câmara de Peixes", fabricante: "Ushio Reinetsu", modelo: "UTSA-22MT", capacidade: "2,08 kW" },
+      { code: "UD-ZZZ-8265-02C", description: "Forçador de Ar | Câmara de Verduras", fabricante: "Ushio Reinetsu", modelo: "UTSA-15HE", capacidade: "1,98 kW" },
+      { code: "UD-ZZZ-8265-02D", description: "Forçador de Ar | Câmara de Lobby", fabricante: "Ushio Reinetsu", modelo: "UTSA-08HA", capacidade: "1,49 kW" },
+    ],
+  },
+  {
+    numero: 8,
+    nome: "Sistema de Climatização: Cozinha",
+    tipo: "Self Contained",
+    local: "Cozinha",
+    equipamentos: [
+      { code: "UD-ZZZ-8250-04", description: "Self Contained", fabricante: "Ushio Reinetsu", modelo: "UAPG-W7HF4DL4", capacidade: "32,6 kW" },
+    ],
+  },
+  {
+    numero: 9,
+    nome: "Sistema de Climatização: Refeitório",
+    tipo: "Self Contained",
+    local: "Refeitório",
+    equipamentos: [
+      { code: "ER-ZZZ-8255B", description: "Self Contained", fabricante: "Ushio Reinetsu", modelo: "UAP-3HF4PL4", capacidade: "17,1 kW" },
+    ],
+  },
+  {
+    numero: 10,
+    nome: "Sistema de Climatização: Oficina",
+    tipo: "Self Contained",
+    local: "Oficina",
+    equipamentos: [
+      { code: "ER-ZZZ-8255B", description: "Self Contained", fabricante: "Ushio Reinetsu", modelo: "UAP-3HF4PL4", capacidade: "17,1 kW" },
+    ],
+  },
+  {
+    numero: 11,
+    nome: "Sistemas Independentes",
+    tipo: "Misto",
+    local: "Diversos",
+    equipamentos: [
+      { local: "Contêiner de Produção", code: "", description: "Split System Hi-Wall", fabricante: "Elgin", modelo: "HLFE30B2NA", capacidade: "8,79 kW" },
+      { local: "Guindaste", code: "", description: "Rooftop", fabricante: "Supply Marine", modelo: "SMRTA001.25V-PAHST-8A", capacidade: "4,39 kW" },
+    ],
+  },
+];
+
+export const mv23EquipmentData = mv23SystemsData.flatMap(sistema =>
+  sistema.equipamentos.map(equip => ({
+    ...equip,
+    sistema: sistema.numero,
+    local: equip.local || sistema.local,
+    description: equip.description || `${equip.tipo} - ${equip.local}`
+  }))
+);
+
+export const getTiposSistemaMv23 = (): string[] => {
+  return Array.from(new Set(mv23SystemsData.map(sistema => sistema.tipo)));
+};
+
+export const getTotalEquipamentosMv23 = (): number => {
+  return mv23EquipmentData.length;
+};


### PR DESCRIPTION
- Cria um novo arquivo de dados `src/data/mv23Equipment.ts` com os 11 sistemas e 31 equipamentos da unidade MV23.
- Integra os novos dados ao dashboard, atualizando o card da MV23 na tela de unidades para exibir os totais corretos.
- Habilita a visualização da lista de sistemas detalhada para a MV23.